### PR TITLE
Redirect AWS SDK logging output from JCL to SLF4J

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,9 +35,15 @@ repositories {
 dependencies {
     compile 'com.amazonaws:aws-java-sdk-s3:1.11.127'
     compile 'com.beust:jcommander:1.64'
-
+    
+    compile 'commons-logging:commons-logging:1.1.1'
+    compile 'log4j:log4j:1.2.17'
     compile 'org.slf4j:slf4j-api:1.7.25'
     compile 'ch.qos.logback:logback-classic:1.1.3'
+    compile 'org.slf4j:log4j-over-slf4j:1.7.25'
+    compile 'org.slf4j:jcl-over-slf4j:1.7.25'
+    
+    
     compileOnly 'org.projectlombok:lombok:1.16.16'
 
     testCompile('junit:junit:4.11'){

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -2,11 +2,14 @@
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <!-- encoders are assigned the type
-             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
         <encoder>
             <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
+    <logger name="org.apache.http" level="ERROR" />
+    <logger name="o.a.h" level="ERROR" />
+    <logger name="com.amazonaws" level="ERROR" />
 
     <root level="debug">
         <appender-ref ref="STDOUT" />


### PR DESCRIPTION
This gradle update will redirect AWS SDK logging output from JCL to SLF4J. Useful for profiling the amount of HTTP requests made to AWS.

Here's the screenshot of console output when executing test.

![screenshot from 2017-05-14 11-45-52](https://cloud.githubusercontent.com/assets/523289/26031403/b23776a6-389b-11e7-9475-30b248370716.png)
