### PR TITLE
Change IOUtils from internal proprietary API to Commons IO. Fixes #22

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,7 @@ dependencies {
     testCompile 'org.powermock:powermock-module-junit4:1.7.0RC4'
     testCompile 'org.powermock:powermock-module-junit4-rule-agent:1.7.0RC4'
     testCompile 'org.hamcrest:hamcrest-library:1.3'
+    testCompile 'commons-io:commons-io:2.5'
     testCompileOnly 'org.projectlombok:lombok:1.16.16'
 }
 

--- a/src/test/java/tdl/s3/rules/TemporarySyncFolder.java
+++ b/src/test/java/tdl/s3/rules/TemporarySyncFolder.java
@@ -2,9 +2,9 @@ package tdl.s3.rules;
 
 import ch.qos.logback.core.encoder.ByteArrayUtil;
 import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.io.IOUtils;
 import org.junit.rules.ExternalResource;
 import org.junit.rules.TemporaryFolder;
-import sun.misc.IOUtils;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -95,7 +95,7 @@ public class TemporarySyncFolder extends ExternalResource {
             long read = 0;
             for (int i = 1; read < fileSize; i++) {
                 int chunkSize = fileSize - read > PART_SIZE_IN_BYTES ? PART_SIZE_IN_BYTES : (int) (fileSize - read);
-                byte[] chunk = IOUtils.readFully(fileInputStream, chunkSize, true);
+                byte[] chunk = IOUtils.readFully(fileInputStream, chunkSize);
                 String hash = Hex.encodeHexString(digest.digest(chunk));
                 result.put(i, hash);
                 read += chunk.length;


### PR DESCRIPTION
This fixes #22 by replacing IOUtils from internal API to the one provided by Commons IO library.