### PR TITLE
Relativize file path in log.

### DIFF
--- a/src/main/java/tdl/s3/helpers/FileHelper.java
+++ b/src/main/java/tdl/s3/helpers/FileHelper.java
@@ -3,6 +3,7 @@ package tdl.s3.helpers;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
 public final class FileHelper {
 
@@ -22,5 +23,9 @@ public final class FileHelper {
                 .normalize()
                 .getParent();
         return fileDirectory.resolve(lockFileName);
+    }
+
+    public static String getRelativeFilePathToCwd(File file) {
+        return Paths.get(".").toUri().relativize(file.toURI()).getPath();
     }
 }

--- a/src/main/java/tdl/s3/upload/FileUploaderImpl.java
+++ b/src/main/java/tdl/s3/upload/FileUploaderImpl.java
@@ -4,6 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.io.File;
 import java.io.IOException;
+import tdl.s3.helpers.FileHelper;
 import tdl.s3.sync.destination.Destination;
 import tdl.s3.sync.destination.DestinationOperationException;
 
@@ -32,20 +33,21 @@ public class FileUploaderImpl implements FileUploader {
     }
 
     private void upload(File file, String path, int retry) throws UploadingException {
-        log.info("Uploading file " + file);
+        String filePath = FileHelper.getRelativeFilePathToCwd(file);
+        log.info("Uploading file " + filePath);
         try {
             uploadInternal(file, path);
         } catch (IOException | DestinationOperationException e) {
             //TODO: Might need to change to loop instead of recursive construct
             if (retry == 0) {
                 log.error("Error during uploading, can't upload file due to exception: " + e.getMessage());
-                throw new UploadingException("Can't upload file " + file + " due to error " + e.getMessage(), e);
+                throw new UploadingException("Can't upload file " + filePath + " due to error " + e.getMessage(), e);
             } else {
                 log.warn("Error during uploading : " + e.getMessage() + " Trying next time...");
                 upload(file, path, retry - 1);
             }
         } finally {
-            log.info("Finished uploading file " + file);
+            log.info("Finished uploading file " + filePath);
         }
     }
 

--- a/src/test/java/tdl/s3/helpers/FileHelperTest.java
+++ b/src/test/java/tdl/s3/helpers/FileHelperTest.java
@@ -1,5 +1,6 @@
 package tdl.s3.helpers;
 
+import java.io.File;
 import org.junit.Test;
 
 import java.nio.file.Path;
@@ -36,5 +37,21 @@ public class FileHelperTest {
         Path path = Paths.get("src", "test", "resources", "test_lock", "file2.txt");
         boolean exists = FileHelper.lockFileExists(path.toFile());
         assertFalse(exists);
+    }
+    
+    @Test
+    public void getRelativeFilePathToCwd()
+    {
+        Path path = Paths.get("src", "test", "resources", "test_lock", "file2.txt");
+        String expected = "src/test/resources/test_lock/file2.txt";
+        File relativeFile = path.toFile();
+        assertTrue(relativeFile.getPath().equals(expected));
+        assertEquals(FileHelper.getRelativeFilePathToCwd(relativeFile), expected);
+        
+        Path absolutePath = path.toAbsolutePath();
+        File absoluteFile = absolutePath.toFile();
+        assertFalse(absoluteFile.getPath().startsWith(expected));
+        assertTrue(absoluteFile.getPath().endsWith(expected));
+        assertEquals(FileHelper.getRelativeFilePathToCwd(absoluteFile), expected);
     }
 }


### PR DESCRIPTION
This will relativize file displayed in the log to the current working directory to obscure private information about the current user.